### PR TITLE
Add compiler options to CastXML

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -62,6 +62,7 @@ XDress currently has the following external dependencies,
     #. `Clang/LLVM <http://llvm.org/releases/>`_, optional for C/C++
     #. `pycparser <https://bitbucket.org/eliben/pycparser>`_, optional for C
     #. `GCC-XML <http://www.gccxml.org/HTML/Index.html>`_, optional for C++
+    #. `CastXML <https://github.com/CastXML/CastXML>`_, optional for C++
     #. `dOxygen <http://www.doxygen.org/>`_, optional for docstrings
     #. `lxml <http://lxml.de/>`_, optional (but nice!)
     #. `argcomplete <https://argcomplete.readthedocs.org/en/latest/>`_, optional for BASH completion

--- a/xdress/utils.py
+++ b/xdress/utils.py
@@ -12,7 +12,9 @@ import re
 import ast
 import sys
 import glob
+import platform
 import functools
+import subprocess
 from copy import deepcopy
 from pprint import pformat
 from collections import Mapping, Iterable, Hashable, Sequence, namedtuple
@@ -917,3 +919,20 @@ def ensure_apiname(name):
     ensured = name._replace(**updates)
     return name if name == ensured else ensured
 
+# From pygccxml 1.7.1
+def create_compiler_path(xml_generator, compiler_path=None):
+    """Try to guess a path for the compiler.
+    Only needed with castxml on Mac or Linux.
+    """
+
+    if xml_generator == 'castxml' and compiler_path is None:
+        if platform.system() != 'Windows':
+            # On windows there is no need for the compiler path
+            p = subprocess.Popen(
+                ['which', 'clang++'], stdout=subprocess.PIPE)
+            compiler_path = p.stdout.read().decode("utf-8").rstrip()
+            # No clang found; use gcc
+            if compiler_path == '':
+                compiler_path = '/usr/bin/c++'
+
+    return compiler_path


### PR DESCRIPTION
Some code courtesy of the PyGCCXML project.

Previously, testing on Mac and Linux I couldn't even get it to work with the stdlib. Had a look at PyGCCXML (which supports CastXML now) and turns out a few more commandline options need to be passed to it to work properly.

Tests still don't pass yet, but they get a bit further.
